### PR TITLE
watcher: Change interval to latency option

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -67,7 +67,7 @@ func (w *FSEventsWatcher) Run(ctx context.Context) error {
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 
-	cmd := exec.CommandContext(ctx, "fswatch", "-n", "-interval", "0.1", w.directory)
+	cmd := exec.CommandContext(ctx, "fswatch", "-n", "-l", "0.1", w.directory)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return oops.Wrapf(err, "")


### PR DESCRIPTION
fswatch recently updated and deprecated the -interval option. There was no communication I could find for this but the latency option should be the equivalent. It has existed for a while so should be safe to switch over to.