### PR TITLE
go executor: restart KeepAlive tasks on clean exit

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -660,6 +660,14 @@ func (e *Executor) runPass() {
 							simpleEvent: execution.simpleEvent(),
 							Error:       err,
 						})
+					} else if task.KeepAlive {
+						// A KeepAlive task should never exit cleanly on its own —
+						// treat it as an error so it gets restarted.
+						execution.state = taskExecutionState_error
+						e.publishEvent(&TaskFailedEvent{
+							simpleEvent: execution.simpleEvent(),
+							Error:       fmt.Errorf("keep-alive task %s exited unexpectedly", task.Name),
+						})
 					} else {
 						execution.state = taskExecutionState_done
 						e.publishEvent(&TaskCompletedEvent{


### PR DESCRIPTION
## Summary

- A `KeepAlive` task that exits with no error and no context cancellation (e.g. an fx service that catches SIGTERM and shuts down gracefully with exit code 0) was previously treated as "done" and never restarted
- This treats a clean exit of a KeepAlive task as an error so the existing KeepAlive restart path kicks in
- The `KeepAlive` field's doc comment says "this task will be restarted when it exits, regardless of exit code" — this change makes the implementation match that intent

## Context

Local dev eventsworker (and other fx-based services) occasionally receive external signals, fx catches them and exits cleanly (code 0), and taskrunner doesn't restart because `KeepAlive` only checked for `taskExecutionState_error`, not `taskExecutionState_done`.

## Test plan

- [x] `go test ./...` passes
- [ ] Run taskrunner locally, kill a KeepAlive service with `kill <pid>`, verify it restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pylon-labs/codesmith/taskrunner/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->