### PR TITLE
fix: treat bare bool flags as true

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -448,6 +448,11 @@ func (e *Executor) parseTaskFlagsIntoMap(taskName string, flags []string) map[st
 		taskFlag := e.taskFlagsRegistry[taskName][key]
 		flagValErrMsg := fmt.Sprintf("The type for the `%s` flag is `%s`. Please use `%s`", key, taskFlag.ValueType, flagTypeToGetter[taskFlag.ValueType])
 
+		// Bare boolean flags (e.g. --dry-run without =value) mean true.
+		if val == "" && taskFlag.ValueType == BoolTypeFlag {
+			val = "true"
+		}
+
 		// If no val was passed, use the default flagArg that is already in the taskFlagsMap.
 		if val != "" {
 			flagArg := FlagArg{

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -100,7 +100,8 @@ func TestParseTaskOptionsListToMap(t *testing.T) {
 		expectedFlagCVal     *int
 		expectedFlagDVal     *float64
 		expectedFlagEVal     *time.Duration
-		expectFlagFValIsNil  bool
+		expectedFlagFVal     *bool
+		expectFlagFNil       bool
 		invalidFlagPanicVal  string
 	}{
 		{
@@ -146,9 +147,9 @@ func TestParseTaskOptionsListToMap(t *testing.T) {
 			expectedFlagEVal: durationPtr(time.Duration(11 * time.Hour)),
 		},
 		{
-			description:         "Should return nil if no arg passed to variable flag and no Default defined",
-			flagArgs:            []string{"-f"},
-			expectFlagFValIsNil: true,
+			description:      "Bare bool flag without =value should be treated as true",
+			flagArgs:         []string{"-f"},
+			expectedFlagFVal: boolPtr(true),
 		},
 		{
 			description:          "Should store Default values for all flags and Value nil when no args are passed",
@@ -158,7 +159,7 @@ func TestParseTaskOptionsListToMap(t *testing.T) {
 			expectedFlagBVal:     stringPtr("presidential dolphin"),
 			expectedFlagCVal:     intPtr(10),
 			expectedFlagDVal:     float64Ptr(1.72),
-			expectFlagFValIsNil:  true,
+			expectFlagFNil:       true,
 		},
 		{
 			description:         "Should panic if there are multiple `=`s in the flag",
@@ -280,9 +281,11 @@ func TestParseTaskOptionsListToMap(t *testing.T) {
 					}
 				}
 
-				if tc.expectFlagFValIsNil {
-					flagArg := flagsMap["f"]
-					assert.Nil(t, flagArg.BoolVal())
+				if tc.expectedFlagFVal != nil {
+					assert.Equal(t, *tc.expectedFlagFVal, *flagsMap["f"].BoolVal())
+				}
+				if tc.expectFlagFNil {
+					assert.Nil(t, flagsMap["f"].BoolVal())
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- Bare boolean flags like `--dry-run` (without `=true`) are now treated as `true`
- Previously, `--dry-run` was silently ignored because the flag parser only populated the `FlagArg` when a value was provided via `=` (e.g. `--dry-run=true`)
- This matches standard CLI conventions where passing a boolean flag without a value means "enable it"

## Test plan

- [x] Updated existing test case for bare bool flags
- [x] All `TestParseTaskOptionsListToMap` subtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pylon-labs/codesmith/taskrunner/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782510692&installation_id=48224246&pr_number=13&repository=pylon-labs%2Ftaskrunner&return_to=https%3A%2F%2Fgithub.com%2Fpylon-labs%2Ftaskrunner%2Fpull%2F13&signature=2e8df7176cacafa7cc294ae49d732e640dceb540db07fd29f3691f595a7ae186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->