### PR TITLE
fix: distinguish bare bool flags from explicit empty value

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -449,7 +449,9 @@ func (e *Executor) parseTaskFlagsIntoMap(taskName string, flags []string) map[st
 		flagValErrMsg := fmt.Sprintf("The type for the `%s` flag is `%s`. Please use `%s`", key, taskFlag.ValueType, flagTypeToGetter[taskFlag.ValueType])
 
 		// Bare boolean flags (e.g. --dry-run without =value) mean true.
-		if val == "" && taskFlag.ValueType == BoolTypeFlag {
+		// len(splitFlag)==1 means no "=" was present; len(splitFlag)==2 with
+		// empty val means "--flag=" which is an explicit empty value, not bare.
+		if val == "" && len(splitFlag) == 1 && taskFlag.ValueType == BoolTypeFlag {
 			val = "true"
 		}
 

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -152,6 +152,11 @@ func TestParseTaskOptionsListToMap(t *testing.T) {
 			expectedFlagFVal: boolPtr(true),
 		},
 		{
+			description:    "Explicit empty bool flag (--flag=) should not default to true",
+			flagArgs:       []string{"-f="},
+			expectFlagFNil: true,
+		},
+		{
 			description:          "Should store Default values for all flags and Value nil when no args are passed",
 			flagArgs:             []string{},
 			expectedFlagAVal:     boolPtr(true),


### PR DESCRIPTION
## Summary

Follow-up to #13. The previous fix treated both `--flag` (bare) and `--flag=` (explicit empty) as `true`. This is wrong — `--flag=$UNSET_VAR` expanding to `--flag=` should not silently activate the flag.

Now only truly bare flags (`len(splitFlag) == 1`, no `=` present) default to `true`.

## Test plan

- [x] New test: `--flag=` does not default to true
- [x] Existing test: bare `--flag` still treated as true
- [x] All `TestParseTaskOptionsListToMap` subtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pylon-labs/codesmith/taskrunner/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782512367&installation_id=48224246&pr_number=14&repository=pylon-labs%2Ftaskrunner&return_to=https%3A%2F%2Fgithub.com%2Fpylon-labs%2Ftaskrunner%2Fpull%2F14&signature=f45453be7ea0a1fc52ba1f14143e82311add8ca0da4c37578213ff97f37ee980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->