### PR TITLE
go executor: reset canceled keepalive before restart

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -651,14 +651,17 @@ func (e *Executor) runPass() {
 						duration = time.Since(started)
 					}
 
+					shouldResetCanceledKeepAlive := false
 					if ctx.Err() == context.Canceled {
+						wasInvalidated := execution.state == taskExecutionState_invalid
 						// Only move ourselves to permanently canceled if taskrunner is shutting down. Note
 						// that the invalidation codepath already set the state as invalid, so there is
 						// no else statement.
 						if e.ctx.Err() != nil {
 							execution.state = taskExecutionState_canceled
-						} else if task.KeepAlive && execution.ctx.Err() == nil {
+						} else if task.KeepAlive {
 							execution.state = taskExecutionState_invalid
+							shouldResetCanceledKeepAlive = execution.ctx.Err() != nil && !wasInvalidated
 						}
 						e.publishEvent(&TaskStoppedEvent{
 							simpleEvent: execution.simpleEvent(),
@@ -690,6 +693,10 @@ func (e *Executor) runPass() {
 					// invalidations occur after exit so that those channels do not block,
 					// waiting for this to complete.
 					execution.terminalCh <- struct{}{}
+					if shouldResetCanceledKeepAlive {
+						execution.ctx, execution.cancel = context.WithCancel(e.ctx)
+						execution.terminalCh = make(chan struct{}, 1)
+					}
 
 					if task.KeepAlive && execution.state == taskExecutionState_error {
 						e.Invalidate(task, KeepAliveStopped{})

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -66,6 +66,52 @@ func TestKeepAliveTaskRestartsAfterInvalidationCancellation(t *testing.T) {
 	}
 }
 
+func TestKeepAliveTaskRestartsAfterTaskContextCancellation(t *testing.T) {
+	config := &config.Config{}
+	started := make(chan struct{}, 2)
+
+	task := &Task{
+		Name:      "keepalive",
+		KeepAlive: true,
+		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+			started <- struct{}{}
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	executor := NewExecutor(config, []*Task{task})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Run(ctx, []string{task.Name}, &Runtime{})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for keepalive task to start")
+	}
+
+	executor.taskExecution(task).cancel()
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for keepalive task to restart after task context cancellation")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for executor to stop")
+	}
+}
+
 func boolPtr(i bool) *bool {
 	return &i
 }

--- a/task_execution.go
+++ b/task_execution.go
@@ -71,8 +71,8 @@ func (e *taskExecution) invalidate(executionCtx context.Context) {
 		return
 	}
 
-	e.cancel()
 	e.state = taskExecutionState_invalid
+	e.cancel()
 	e.ctx, e.cancel = context.WithCancel(executionCtx)
 	<-e.terminalCh
 	e.terminalCh = make(chan struct{}, 1)


### PR DESCRIPTION
## Summary
- reset canceled KeepAlive execution contexts/channels before scheduling a restart
- keep the existing invalidate() reset path untouched when it already installed a fresh context
- add a regression test for task-context cancellation restart behavior

## Testing
- go test ./...

Follow-up to pylon-labs/taskrunner#15 and addresses the app PR review finding.