### PR TITLE
go executor: skip invalidation delay after task completion

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -171,22 +171,24 @@ func (e *Executor) runInvalidationLoop() {
 				return
 
 			case <-timer.C:
-				e.evaluateInvalidationPlan()
+				e.evaluateInvalidationPlan(true)
 				go e.runPass()
 			}
 		}
 	}()
 }
 
-// evaluateInvalidationPlan find all tasks that have pending invalidations
+// evaluateInvalidationPlan finds all tasks that have pending invalidations
 // and kicks off their re-execution.
-func (e *Executor) evaluateInvalidationPlan() {
-	// Wait for potential side effects from the last evaluation to complete.
-	// For instance, if task A depends on task B and task B changes a file that
-	// task A needs, then we want to wait for the file events from task B to propagate
-	// before evaluating the new plan. We must rely on timing because we cannot
-	// follow and wait for the execution to come back through fswatch.
-	time.Sleep(time.Millisecond * 1000)
+func (e *Executor) evaluateInvalidationPlan(waitForFilesystemEvents bool) {
+	if waitForFilesystemEvents {
+		// Wait for potential side effects from the last evaluation to complete.
+		// For instance, if task A depends on task B and task B changes a file that
+		// task A needs, then we want to wait for the file events from task B to propagate
+		// before evaluating the new plan. We must rely on timing because we cannot
+		// follow and wait for the execution to come back through fswatch.
+		time.Sleep(time.Millisecond * 1000)
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -703,7 +705,7 @@ func (e *Executor) runPass() {
 					}
 
 					if err == nil {
-						e.evaluateInvalidationPlan()
+						e.evaluateInvalidationPlan(false)
 					}
 
 					e.runPass()

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -112,6 +112,57 @@ func TestKeepAliveTaskRestartsAfterTaskContextCancellation(t *testing.T) {
 	}
 }
 
+func TestDependentTaskStartsWithoutInvalidationDelay(t *testing.T) {
+	config := &config.Config{}
+	dependencyDone := make(chan struct{}, 1)
+	dependentStarted := make(chan struct{}, 1)
+
+	dependency := &Task{
+		Name: "dependency",
+		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+			dependencyDone <- struct{}{}
+			return nil
+		},
+	}
+	dependent := &Task{
+		Name:         "dependent",
+		Dependencies: []*Task{dependency},
+		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+			dependentStarted <- struct{}{}
+			return nil
+		},
+	}
+
+	executor := NewExecutor(config, []*Task{dependency, dependent})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Run(ctx, []string{dependent.Name}, &Runtime{})
+	}()
+
+	select {
+	case <-dependencyDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for dependency task to complete")
+	}
+
+	select {
+	case <-dependentStarted:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("dependent task start was delayed by invalidation planning")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for executor to stop")
+	}
+}
+
 func boolPtr(i bool) *bool {
 	return &i
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pylon-labs/taskrunner"
 	"github.com/pylon-labs/taskrunner/config"
 	"github.com/pylon-labs/taskrunner/shell"
+	"github.com/pylon-labs/taskrunner/watcher"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,6 +97,32 @@ func (f TestInvalidationEvent) Description() string {
 	return "the test case decided to invalidate the task"
 }
 
+type testWatcher struct {
+	events chan watcher.WatchEvent
+}
+
+func newTestWatcher() *testWatcher {
+	return &testWatcher{
+		events: make(chan watcher.WatchEvent),
+	}
+}
+
+func (w *testWatcher) Events() <-chan watcher.WatchEvent {
+	return w.events
+}
+
+func (w *testWatcher) Run(ctx context.Context) error {
+	<-ctx.Done()
+	close(w.events)
+	return nil
+}
+
+func withTestWatcher() taskrunner.ExecutorOption {
+	return taskrunner.WithWatcherEnhancer(func(w watcher.Watcher) watcher.Watcher {
+		return newTestWatcher()
+	})
+}
+
 // consumeUntil consumes the events channel until an event matching
 // the specified kind appears.
 func consumeUntil(t *testing.T, events <-chan taskrunner.ExecutorEvent, kind taskrunner.ExecutorEventKind) taskrunner.ExecutorEvent {
@@ -140,7 +167,7 @@ func TestExecutorInvalidations(t *testing.T) {
 		{
 			"dependency invalidated",
 			func(t *testing.T) {
-				executor := taskrunner.NewExecutor(config, tasks, taskrunner.WithWatchMode(true))
+				executor := taskrunner.NewExecutor(config, tasks, taskrunner.WithWatchMode(true), withTestWatcher())
 				ctx, cancel := context.WithCancel(context.Background())
 				events := executor.Subscribe()
 
@@ -166,7 +193,7 @@ func TestExecutorInvalidations(t *testing.T) {
 		{
 			"leaf invalidated",
 			func(t *testing.T) {
-				executor := taskrunner.NewExecutor(config, tasks)
+				executor := taskrunner.NewExecutor(config, tasks, taskrunner.WithWatchMode(true), withTestWatcher())
 				ctx, cancel := context.WithCancel(context.Background())
 				events := executor.Subscribe()
 


### PR DESCRIPTION
## Summary
- keep the filesystem propagation wait on watcher-driven invalidation planning
- skip that 1s wait after ordinary successful task completion so dependent tasks can start promptly
- make the invalidation test explicitly watch-mode and add a regression test for dependency startup latency

## Test plan
- go test ./...
