### PR TITLE
go executor: coalesce invalidation wakeups

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -225,7 +225,10 @@ func (e *Executor) Invalidate(task *Task, event InvalidationEvent) {
 		return
 	}
 
-	e.invalidationCh <- struct{}{}
+	select {
+	case e.invalidationCh <- struct{}{}:
+	default:
+	}
 }
 
 func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime) error {

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -163,6 +163,35 @@ func TestDependentTaskStartsWithoutInvalidationDelay(t *testing.T) {
 	}
 }
 
+func TestInvalidateCoalescesWakeupsWithoutBlocking(t *testing.T) {
+	config := &config.Config{}
+	task := &Task{
+		Name: "task",
+		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+			return nil
+		},
+	}
+
+	executor := NewExecutor(config, []*Task{task})
+	tasks := make(taskSet)
+	execution, _ := tasks.add(context.Background(), task)
+	execution.state = taskExecutionState_done
+	executor.tasks = tasks
+
+	done := make(chan struct{})
+	go func() {
+		executor.Invalidate(task, testInvalidationEvent{})
+		executor.Invalidate(task, testInvalidationEvent{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for duplicate invalidations to coalesce")
+	}
+}
+
 func boolPtr(i bool) *bool {
 	return &i
 }

--- a/watch.go
+++ b/watch.go
@@ -37,7 +37,7 @@ func (e *Executor) runWatch(ctx context.Context) {
 		for event := range watcher.Events() {
 			for task := range e.tasks {
 				if IsTaskSource(task, event.RelativeFilename) {
-					go e.Invalidate(task, FileChange{
+					e.Invalidate(task, FileChange{
 						File: event.RelativeFilename,
 					})
 				}


### PR DESCRIPTION
Summary:
- Coalesce duplicate invalidation wakeups with a non-blocking channel send.
- Invalidate watch matches inline now that invalidation cannot block.
- Add regression coverage for duplicate invalidations.

Tests:
- go test ./...