### PR TITLE
go executor: prevent invalidation deadlocks

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -157,11 +157,14 @@ func (e *Executor) publishEvent(event ExecutorEvent) {
 // runInvalidationLoop kicks off a background goroutine that plans and
 // runs re-executions after invalidations occur. It coalesces invalidations
 // every second.
-func (e *Executor) runInvalidationLoop() {
+func (e *Executor) runInvalidationLoop() <-chan struct{} {
 	timer := time.NewTimer(time.Second)
 	timer.Stop()
+	done := make(chan struct{})
 
 	go func() {
+		defer close(done)
+		defer timer.Stop()
 		for {
 			select {
 			case <-e.invalidationCh:
@@ -172,10 +175,11 @@ func (e *Executor) runInvalidationLoop() {
 
 			case <-timer.C:
 				e.evaluateInvalidationPlan(true)
-				go e.runPass()
 			}
 		}
 	}()
+
+	return done
 }
 
 // evaluateInvalidationPlan finds all tasks that have pending invalidations
@@ -187,32 +191,60 @@ func (e *Executor) evaluateInvalidationPlan(waitForFilesystemEvents bool) {
 		// task A needs, then we want to wait for the file events from task B to propagate
 		// before evaluating the new plan. We must rely on timing because we cannot
 		// follow and wait for the execution to come back through fswatch.
-		time.Sleep(time.Millisecond * 1000)
+		select {
+		case <-time.After(time.Second):
+		case <-e.ctx.Done():
+			return
+		}
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	type plannedInvalidation struct {
+		execution        *taskExecution
+		terminalCh       chan struct{}
+		invalidationDone chan struct{}
+		cancel           func()
+		event            *TaskInvalidatedEvent
+	}
 
-	var toInvalidate []*taskExecution
+	e.mu.Lock()
+	var invalidations []plannedInvalidation
 	for _, execution := range e.tasks {
-		if len(execution.pendingInvalidations) == 0 || execution.state == taskExecutionState_invalid {
+		reasons, terminalCh, invalidationDone, cancel, ok := execution.beginInvalidation()
+		if !ok {
 			continue
 		}
 
-		var reasons []InvalidationEvent
-		for reason := range execution.pendingInvalidations {
-			reasons = append(reasons, reason)
-		}
-
-		e.publishEvent(&TaskInvalidatedEvent{
-			simpleEvent: execution.simpleEvent(),
-			Reasons:     reasons,
+		invalidations = append(invalidations, plannedInvalidation{
+			execution:        execution,
+			terminalCh:       terminalCh,
+			invalidationDone: invalidationDone,
+			cancel:           cancel,
+			event: &TaskInvalidatedEvent{
+				simpleEvent: execution.simpleEvent(),
+				Reasons:     reasons,
+			},
 		})
+	}
+	e.mu.Unlock()
 
-		toInvalidate = append(toInvalidate, execution)
+	for _, invalidation := range invalidations {
+		e.publishEvent(invalidation.event)
+	}
+	for _, invalidation := range invalidations {
+		invalidation.cancel()
+	}
+	for _, invalidation := range invalidations {
+		<-invalidation.terminalCh
 	}
 
-	for _, execution := range toInvalidate {
-		execution.invalidate(e.ctx)
+	e.mu.Lock()
+	for _, invalidation := range invalidations {
+		invalidation.execution.finishInvalidation(e.ctx, invalidation.terminalCh)
+	}
+	e.mu.Unlock()
+
+	e.runPass()
+	for _, invalidation := range invalidations {
+		invalidation.execution.completeInvalidation(invalidation.invalidationDone)
 	}
 }
 
@@ -232,16 +264,18 @@ func (e *Executor) Invalidate(task *Task, event InvalidationEvent) {
 }
 
 func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime) error {
-	e.ctx = ctx
+	executionCtx, cancel := context.WithCancel(ctx)
+	e.ctx = executionCtx
+	var invalidationLoopDone <-chan struct{}
 	defer func() {
+		cancel()
+		if invalidationLoopDone != nil {
+			<-invalidationLoopDone
+		}
 		for _, ch := range e.eventsChs {
 			close(ch)
 		}
 	}()
-	e.runInvalidationLoop()
-	if e.watchMode {
-		e.runWatch(ctx)
-	}
 
 	// Build up the DAG for task executions.
 	taskSet := make(taskSet)
@@ -250,7 +284,7 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 		if task == nil {
 			return oops.Wrapf(errUndefinedTaskName, "task %s is not defined", taskName)
 		}
-		taskSet.add(ctx, task)
+		taskSet.add(executionCtx, task)
 	}
 
 	e.tasks = taskSet
@@ -285,10 +319,33 @@ func (e *Executor) Run(ctx context.Context, taskNames []string, runtime *Runtime
 		return errors
 	}
 
+	invalidationLoopDone = e.runInvalidationLoop()
+	if e.watchMode {
+		e.runWatch(executionCtx, cancel)
+	}
+
+	keepExecutorAlive := false
+	for task := range e.tasks {
+		keepExecutorAlive = keepExecutorAlive || task.KeepAlive
+	}
+	if keepExecutorAlive {
+		e.wg.Go(func() error {
+			<-executionCtx.Done()
+			// Synchronize with runPass so no task can be added after this
+			// lifecycle guard leaves the group.
+			e.mu.Lock()
+			e.mu.Unlock()
+			return nil
+		})
+	}
+
 	e.runPass()
 
 	// Wait on all tasks to exit before stopping.
 	errors = multierr.Append(errors, e.wg.Wait())
+	cancel()
+	<-invalidationLoopDone
+	invalidationLoopDone = nil
 
 	// Run all onStopHooks after stopping.
 	for _, hook := range runtime.onStopHooks {
@@ -618,22 +675,19 @@ func (e *Executor) showTaskFlagHelpText(taskName string) {
 
 // runPass kicks off tasks that are in an executable state.
 func (e *Executor) runPass() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	if e.ctx.Err() != nil {
 		return
 	}
 
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	for task, execution := range e.tasks {
-		if execution.ShouldExecute() {
-			execution.state = taskExecutionState_running
-
-			func(task *Task, execution *taskExecution) {
+		if executionCtx, shouldExecute := execution.start(); shouldExecute {
+			func(task *Task, execution *taskExecution, executionCtx context.Context) {
 				e.wg.Go(func() error {
 					logger := e.provideEventLogger(task)
 
-					ctx := context.WithValue(execution.ctx, loggerKey{}, logger)
+					ctx := context.WithValue(executionCtx, loggerKey{}, logger)
 
 					e.publishEvent(&TaskStartedEvent{
 						simpleEvent: execution.simpleEvent(),
@@ -656,69 +710,74 @@ func (e *Executor) runPass() {
 						duration = time.Since(started)
 					}
 
+					execution.mu.Lock()
+					terminalCh := execution.terminalCh
+					var event ExecutorEvent
 					shouldResetCanceledKeepAlive := false
 					if ctx.Err() == context.Canceled {
-						wasInvalidated := execution.state == taskExecutionState_invalid
+						wasInvalidated := execution.state == taskExecutionState_invalid || execution.invalidating
 						// Only move ourselves to permanently canceled if taskrunner is shutting down. Note
 						// that the invalidation codepath already set the state as invalid, so there is
 						// no else statement.
 						if e.ctx.Err() != nil {
 							execution.state = taskExecutionState_canceled
-						} else if task.KeepAlive {
+						} else if task.KeepAlive && !execution.invalidating {
 							execution.state = taskExecutionState_invalid
 							shouldResetCanceledKeepAlive = execution.ctx.Err() != nil && !wasInvalidated
 						}
-						e.publishEvent(&TaskStoppedEvent{
+						event = &TaskStoppedEvent{
 							simpleEvent: execution.simpleEvent(),
-						})
+						}
 					} else if err != nil {
 						execution.state = taskExecutionState_error
-						e.publishEvent(&TaskFailedEvent{
+						event = &TaskFailedEvent{
 							simpleEvent: execution.simpleEvent(),
 							Error:       err,
-						})
+						}
 					} else if task.KeepAlive {
 						// A KeepAlive task should never exit cleanly on its own —
 						// treat it as an error so it gets restarted.
 						execution.state = taskExecutionState_error
-						e.publishEvent(&TaskFailedEvent{
+						event = &TaskFailedEvent{
 							simpleEvent: execution.simpleEvent(),
 							Error:       fmt.Errorf("keep-alive task %s exited unexpectedly", task.Name),
-						})
+						}
 					} else {
 						execution.state = taskExecutionState_done
-						e.publishEvent(&TaskCompletedEvent{
+						event = &TaskCompletedEvent{
 							simpleEvent: execution.simpleEvent(),
 							Duration:    duration,
-						})
+						}
 					}
 
-					// It's important that we flush the error/done states before
-					// terminating the channel. It's also important that possible
-					// invalidations occur after exit so that those channels do not block,
-					// waiting for this to complete.
-					execution.terminalCh <- struct{}{}
 					if shouldResetCanceledKeepAlive {
 						execution.ctx, execution.cancel = context.WithCancel(e.ctx)
 						execution.terminalCh = make(chan struct{}, 1)
+						execution.pendingInvalidations = make(map[InvalidationEvent]struct{})
 					}
+					shouldInvalidateStoppedKeepAlive := task.KeepAlive && execution.state == taskExecutionState_error
+					execution.mu.Unlock()
 
-					if task.KeepAlive && execution.state == taskExecutionState_error {
+					e.publishEvent(event)
+					terminalCh <- struct{}{}
+
+					if shouldInvalidateStoppedKeepAlive {
 						e.Invalidate(task, KeepAliveStopped{})
 					}
 
-					if err == nil {
+					if err == nil || ctx.Err() == context.Canceled {
 						e.evaluateInvalidationPlan(false)
+					} else {
+						e.runPass()
 					}
-
-					e.runPass()
+					execution.waitForInvalidation(terminalCh)
 					if err != nil && ctx.Err() != context.Canceled {
 						return err
 					}
 
 					return nil
 				})
-			}(task, execution)
+			}(task, execution, executionCtx)
 
 		}
 	}

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -112,6 +112,77 @@ func TestKeepAliveTaskRestartsAfterTaskContextCancellation(t *testing.T) {
 	}
 }
 
+func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
+	config := &config.Config{}
+	started := make(chan struct{}, 2)
+	cancellationObserved := make(chan struct{}, 1)
+	allowCompletion := make(chan struct{})
+
+	task := &Task{
+		Name:      "keepalive",
+		KeepAlive: true,
+		Run: func(ctx context.Context, shellRun shell.ShellRun) error {
+			started <- struct{}{}
+			<-ctx.Done()
+			select {
+			case cancellationObserved <- struct{}{}:
+				<-allowCompletion
+			default:
+			}
+			return nil
+		},
+	}
+
+	executor := NewExecutor(config, []*Task{task})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Run(ctx, []string{task.Name}, &Runtime{})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for keepalive task to start")
+	}
+
+	executor.Invalidate(task, testInvalidationEvent{})
+	invalidationDone := make(chan struct{})
+	go func() {
+		executor.evaluateInvalidationPlan(false)
+		close(invalidationDone)
+	}()
+
+	select {
+	case <-cancellationObserved:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for keepalive task to observe invalidation cancellation")
+	}
+	close(allowCompletion)
+
+	select {
+	case <-invalidationDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for invalidation to finish after task completion")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for keepalive task to restart after invalidation")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for executor to stop")
+	}
+}
+
 func TestDependentTaskStartsWithoutInvalidationDelay(t *testing.T) {
 	config := &config.Config{}
 	dependencyDone := make(chan struct{}, 1)

--- a/executor_internal_test.go
+++ b/executor_internal_test.go
@@ -20,6 +20,19 @@ func (f testInvalidationEvent) Description() string {
 	return "the test case decided to invalidate the task"
 }
 
+func assertNextEventKind(t *testing.T, events <-chan ExecutorEvent, expected ExecutorEventKind) {
+	t.Helper()
+	select {
+	case event, ok := <-events:
+		if !ok {
+			t.Fatalf("events closed before observing %s", expected)
+		}
+		assert.Equal(t, expected, event.Kind())
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", expected)
+	}
+}
+
 func TestKeepAliveTaskRestartsAfterInvalidationCancellation(t *testing.T) {
 	config := &config.Config{}
 	started := make(chan struct{}, 2)
@@ -48,7 +61,6 @@ func TestKeepAliveTaskRestartsAfterInvalidationCancellation(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for keepalive task to start")
 	}
-
 	executor.Invalidate(task, testInvalidationEvent{})
 
 	select {
@@ -134,6 +146,7 @@ func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
 	}
 
 	executor := NewExecutor(config, []*Task{task})
+	events := executor.Subscribe()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -147,6 +160,7 @@ func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for keepalive task to start")
 	}
+	assertNextEventKind(t, events, ExecutorEventKind_TaskStarted)
 
 	executor.Invalidate(task, testInvalidationEvent{})
 	invalidationDone := make(chan struct{})
@@ -160,12 +174,19 @@ func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for keepalive task to observe invalidation cancellation")
 	}
+	assertNextEventKind(t, events, ExecutorEventKind_TaskInvalidated)
 	close(allowCompletion)
+	assertNextEventKind(t, events, ExecutorEventKind_TaskStopped)
 
 	select {
 	case <-invalidationDone:
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for invalidation to finish after task completion")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("executor stopped before the keepalive task restarted: %v", err)
+	default:
 	}
 
 	select {
@@ -173,6 +194,7 @@ func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for keepalive task to restart after invalidation")
 	}
+	assertNextEventKind(t, events, ExecutorEventKind_TaskStarted)
 
 	cancel()
 	select {
@@ -181,6 +203,94 @@ func TestKeepAliveInvalidationSynchronizesTaskCompletion(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for executor to stop")
 	}
+}
+
+func TestTaskWaitsForInvalidationCompletion(t *testing.T) {
+	task := &Task{Name: "task"}
+	tasks := make(taskSet)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	execution, _ := tasks.add(ctx, task)
+	execution.state = taskExecutionState_running
+	execution.pendingInvalidations[testInvalidationEvent{}] = struct{}{}
+	executionCtx := execution.ctx
+
+	_, terminalCh, invalidationDone, cancelInvalidation, ok := execution.beginInvalidation()
+	assert.True(t, ok)
+	select {
+	case <-executionCtx.Done():
+		t.Fatal("beginInvalidation canceled the task before its event could be published")
+	default:
+	}
+	cancelInvalidation()
+	select {
+	case <-executionCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("captured invalidation cancellation did not stop the task")
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		execution.waitForInvalidation(terminalCh)
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		t.Fatal("task stopped waiting before invalidation completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	execution.finishInvalidation(ctx, terminalCh)
+	execution.completeInvalidation(invalidationDone)
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("task did not stop waiting after invalidation completed")
+	}
+	assert.Equal(t, taskExecutionState(taskExecutionState_invalid), execution.getState())
+}
+
+func TestInvalidatingDependencyIsNotReady(t *testing.T) {
+	dependency := &Task{Name: "dependency"}
+	dependent := &Task{
+		Name:         "dependent",
+		Dependencies: []*Task{dependency},
+	}
+	tasks := make(taskSet)
+	dependentExecution, _ := tasks.add(context.Background(), dependent)
+	dependencyExecution := tasks[dependency]
+	dependencyExecution.state = taskExecutionState_done
+	dependencyExecution.invalidating = true
+
+	_, ready := dependentExecution.start()
+	assert.False(t, ready)
+}
+
+func TestShouldInvalidateCanReadTaskState(t *testing.T) {
+	task := &Task{Name: "task"}
+	tasks := make(taskSet)
+	execution, _ := tasks.add(context.Background(), task)
+	execution.state = taskExecutionState_done
+	handler := NewTaskHandler(execution)
+	observedState := make(chan TaskHandlerExecutionState, 1)
+	task.ShouldInvalidate = func(event InvalidationEvent) bool {
+		observedState <- handler.State()
+		return false
+	}
+
+	done := make(chan struct{})
+	go func() {
+		execution.Invalidate(testInvalidationEvent{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ShouldInvalidate deadlocked while reading task state")
+	}
+	assert.Equal(t, TaskHandlerExecutionState(TaskHandlerExecutionState_Done), <-observedState)
 }
 
 func TestDependentTaskStartsWithoutInvalidationDelay(t *testing.T) {

--- a/executor_test.go
+++ b/executor_test.go
@@ -2,6 +2,7 @@ package taskrunner_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -121,6 +122,47 @@ func withTestWatcher() taskrunner.ExecutorOption {
 	return taskrunner.WithWatcherEnhancer(func(w watcher.Watcher) watcher.Watcher {
 		return newTestWatcher()
 	})
+}
+
+type failingWatcher struct {
+	events chan watcher.WatchEvent
+	err    error
+}
+
+func (w *failingWatcher) Events() <-chan watcher.WatchEvent {
+	return w.events
+}
+
+func (w *failingWatcher) Run(ctx context.Context) error {
+	close(w.events)
+	return w.err
+}
+
+func TestExecutorReturnsWatcherFailure(t *testing.T) {
+	watcherErr := errors.New("watcher failed")
+	executor := taskrunner.NewExecutor(
+		&config.Config{},
+		[]*taskrunner.Task{{Name: "task"}},
+		taskrunner.WithWatchMode(true),
+		taskrunner.WithWatcherEnhancer(func(w watcher.Watcher) watcher.Watcher {
+			return &failingWatcher{
+				events: make(chan watcher.WatchEvent),
+				err:    watcherErr,
+			}
+		}),
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Run(context.Background(), []string{"task"}, &taskrunner.Runtime{})
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, watcherErr)
+	case <-time.After(time.Second):
+		t.Fatal("executor did not return after watcher failure")
+	}
 }
 
 // consumeUntil consumes the events channel until an event matching

--- a/task_execution.go
+++ b/task_execution.go
@@ -30,10 +30,14 @@ type taskExecution struct {
 	mu         sync.Mutex
 	definition *Task
 
-	ctx        context.Context
-	cancel     func()
-	state      taskExecutionState
-	terminalCh chan struct{}
+	ctx          context.Context
+	cancel       func()
+	state        taskExecutionState
+	invalidating bool
+	terminalCh   chan struct{}
+
+	invalidationDone       chan struct{}
+	invalidationTerminalCh chan struct{}
 
 	dependencies []*taskExecution
 	dependents   []*taskExecution
@@ -48,52 +52,115 @@ func (e *taskExecution) simpleEvent() *simpleEvent {
 	}
 }
 
-// ShouldExecute returns true if the taskExecution is marked
-// invalidated AND all of its dependencies have successfully completed.
-func (e *taskExecution) ShouldExecute() bool {
-	if e.state != taskExecutionState_invalid {
-		return false
-	}
-
-	ready := true
+// start transitions an executable task to running and returns its execution context.
+func (e *taskExecution) start() (context.Context, bool) {
 	for _, dep := range e.dependencies {
-		if dep.state != taskExecutionState_done {
-			ready = false
+		if !dep.isDone() {
+			return nil, false
 		}
 	}
-	return ready
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state != taskExecutionState_invalid || e.invalidating {
+		return nil, false
+	}
+
+	e.state = taskExecutionState_running
+	return e.ctx, true
 }
 
-// invalidate stops the task if running, resets the execution
-// state for the task, then invalidates all dependents.
-func (e *taskExecution) invalidate(executionCtx context.Context) {
-	if e.state == taskExecutionState_invalid || e.state == taskExecutionState_canceled {
+func (e *taskExecution) getState() taskExecutionState {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.state
+}
+
+func (e *taskExecution) isDone() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.state == taskExecutionState_done && !e.invalidating
+}
+
+// beginInvalidation atomically claims a task and returns the cancellation and
+// completion signals needed to finish its invalidation without holding a mutex.
+func (e *taskExecution) beginInvalidation() ([]InvalidationEvent, chan struct{}, chan struct{}, func(), bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(e.pendingInvalidations) == 0 ||
+		e.state == taskExecutionState_invalid ||
+		e.state == taskExecutionState_canceled ||
+		e.invalidating {
+		return nil, nil, nil, nil, false
+	}
+
+	reasons := make([]InvalidationEvent, 0, len(e.pendingInvalidations))
+	for reason := range e.pendingInvalidations {
+		reasons = append(reasons, reason)
+	}
+
+	e.invalidating = true
+	e.invalidationDone = make(chan struct{})
+	e.invalidationTerminalCh = e.terminalCh
+	return reasons, e.terminalCh, e.invalidationDone, e.cancel, true
+}
+
+func (e *taskExecution) finishInvalidation(executionCtx context.Context, terminalCh <-chan struct{}) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.invalidating {
 		return
 	}
 
-	e.state = taskExecutionState_invalid
-	e.cancel()
 	e.ctx, e.cancel = context.WithCancel(executionCtx)
-	<-e.terminalCh
-	e.terminalCh = make(chan struct{}, 1)
+	if executionCtx.Err() != nil {
+		e.state = taskExecutionState_canceled
+	} else {
+		e.state = taskExecutionState_invalid
+	}
+	e.invalidating = false
+	if e.terminalCh == terminalCh {
+		e.terminalCh = make(chan struct{}, 1)
+	}
 	e.pendingInvalidations = make(map[InvalidationEvent]struct{})
+}
+
+func (e *taskExecution) completeInvalidation(invalidationDone chan struct{}) {
+	e.mu.Lock()
+	if e.invalidationDone == invalidationDone {
+		e.invalidationDone = nil
+		e.invalidationTerminalCh = nil
+	}
+	close(invalidationDone)
+	e.mu.Unlock()
+}
+
+func (e *taskExecution) waitForInvalidation(terminalCh chan struct{}) {
+	e.mu.Lock()
+	var invalidationDone chan struct{}
+	if e.invalidationTerminalCh == terminalCh {
+		invalidationDone = e.invalidationDone
+	}
+	e.mu.Unlock()
+	if invalidationDone != nil {
+		<-invalidationDone
+	}
 }
 
 // Invalidate marks a taskExecution as invalid. It does not produce
 // side effects by itself.
 func (e *taskExecution) Invalidate(event InvalidationEvent) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	if e.state == taskExecutionState_invalid {
-		return false
-	}
-
 	if e.definition.ShouldInvalidate != nil && !e.definition.ShouldInvalidate(event) {
 		return false
 	}
 
+	e.mu.Lock()
+	if e.state == taskExecutionState_invalid {
+		e.mu.Unlock()
+		return false
+	}
 	e.pendingInvalidations[event] = struct{}{}
+	e.mu.Unlock()
 
 	for _, dep := range e.dependents {
 		dep.Invalidate(DependencyChange{

--- a/task_handler.go
+++ b/task_handler.go
@@ -41,7 +41,7 @@ var TaskHandlerExecutionStateMap = map[taskExecutionState]TaskHandlerExecutionSt
 }
 
 func (h *TaskHandler) State() TaskHandlerExecutionState {
-	return TaskHandlerExecutionStateMap[h.execution.state]
+	return TaskHandlerExecutionStateMap[h.execution.getState()]
 }
 
 func (e *Executor) Tasks() []*TaskHandler {

--- a/watch.go
+++ b/watch.go
@@ -27,7 +27,7 @@ func IsTaskSource(task *Task, path string) (matches bool) {
 	return matches
 }
 
-func (e *Executor) runWatch(ctx context.Context) {
+func (e *Executor) runWatch(ctx context.Context, cancel context.CancelFunc) {
 	watcher := watcher.NewWatcher(e.config.WorkingDir)
 	for _, enhancer := range e.watcherEnhancers {
 		watcher = enhancer(watcher)
@@ -46,8 +46,13 @@ func (e *Executor) runWatch(ctx context.Context) {
 	}()
 
 	e.wg.Go(func() error {
-		if err := watcher.Run(ctx); err != nil {
-			if ctx.Err() != context.Canceled {
+		err := watcher.Run(ctx)
+		wasCanceled := ctx.Err() == context.Canceled
+		cancel()
+		e.mu.Lock()
+		e.mu.Unlock()
+		if err != nil {
+			if !wasCanceled {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

- synchronize each task execution lifecycle across state, context, pending invalidations, and terminal-channel generations
- split invalidation into claim, event publication, cancellation, terminal wait, state reset, and restart scheduling without holding the executor mutex across a channel wait
- keep completing tasks alive until invalidation has registered the replacement execution, and prevent dependents from starting against an invalidating dependency
- join the invalidation loop during teardown and make watcher failures cancel through the same scheduling barrier
- preserve the observable Invalidated → Stopped event order and allow ShouldInvalidate callbacks to inspect task state safely

Supersedes #17 by folding its pending-invalidation cleanup into the synchronized lifecycle transition.

## Root cause

The captured SIGQUIT dump showed an invalidation goroutine blocked on a task terminal channel for 122 minutes while holding Executor.mu. Thirteen task goroutines were then blocked trying to enter the next execution pass through that same mutex.

PR #15 / 59908fc introduced cross-goroutine KeepAlive lifecycle reads. PR #16 / 6472f72 then added a second unsynchronized writer that replaced ctx and terminalCh from task completion. Completion could swap in a fresh empty terminal channel just before invalidation evaluated its receive, permanently losing the signal. The pre-existing global mutex around that receive amplified one lost signal into a whole-executor deadlock.

## Regression evidence

The regression test was committed first and failed under the race detector before the fix:

```
WARNING: DATA RACE
executor.go:669
 task_execution.go:76
testing.go:1712: race detected during execution of test
```

The fix also closes two adjacent teardown gaps found during review: dynamic errgroup registration during restart, and a watcher error being trapped behind a lifecycle guard.

## Verification

- `go test -race . -run "^(TestKeepAliveInvalidationSynchronizesTaskCompletion|TestTaskWaitsForInvalidationCompletion|TestInvalidatingDependencyIsNotReady|TestShouldInvalidateCanReadTaskState|TestExecutorReturnsWatcherFailure)$" -count=20`
- `go test -race ./... -count=1`
- two independent concurrency reviews; no remaining Critical or Important findings
